### PR TITLE
fix path import problem

### DIFF
--- a/backoffice/vbt_plot/optimize_plot.py
+++ b/backoffice/vbt_plot/optimize_plot.py
@@ -2,9 +2,12 @@ import pandas as pd
 import plotly.graph_objects as go
 import plotly.express as px
 import matplotlib.pyplot as plt
+import os
 
+fig_path = f"{os.getcwd()}/../data_base/OPTIMIZATION"
+os.makedirs(fig_path, exist_ok=True)
 
-def two_parameter_plot(df_data: pd.DataFrame, perf_name: str, par_name1: str, par_name2: str, show: False):
+def two_parameter_plot(df_data: pd.DataFrame, perf_name: str, par_name1: str, par_name2: str, fig_name: str=None, show: bool=False):
     
     """
     Create and display a set of plots for analyzing two parameters and performance.
@@ -15,6 +18,7 @@ def two_parameter_plot(df_data: pd.DataFrame, perf_name: str, par_name1: str, pa
     par_name1 (str): The name of the first parameter column in df_data.
     par_name2 (str): The name of the second parameter column in df_data.
     """
+
     # All_Heatmap
     fig = go.Figure(data=go.Heatmap(
             z = df_data[perf_name],
@@ -22,7 +26,7 @@ def two_parameter_plot(df_data: pd.DataFrame, perf_name: str, par_name1: str, pa
             y = df_data[par_name2],
             colorscale='Viridis'))
     fig.update_layout(title = f"All_Heatmap_{perf_name}", width=600, height=400)
-    fig.write_image(f"path/plot.png") # TODO
+    #fig.write_image(f"{fig_path}/all_heatmap.png") # TODO:save the figure in right path
     if show:
         fig.show()
 
@@ -37,7 +41,7 @@ def two_parameter_plot(df_data: pd.DataFrame, perf_name: str, par_name1: str, pa
             title = f"Range_Heatmap_{perf_name}",
             )
     fig.update_layout(width=600, height=400)
-    fig.write_image(f"path/plot.png") # TODO
+    #fig.write_image(f"{fig_path}/range_heatmap.png") # TODO:save the figure in right path
     if show:
         fig.show()
 
@@ -46,13 +50,14 @@ def two_parameter_plot(df_data: pd.DataFrame, perf_name: str, par_name1: str, pa
     fig, ax = plt.subplots(figsize=(6, 4))
     ax.hist(x = df_data[perf_name], bins=10)
     plt.title(f"Histgram_{perf_name}", fontsize=18)
-
     plt.xlabel(perf_name, fontsize=12)
     plt.ylabel('Times', fontsize=12)
-
     plt.xticks(fontsize=15)
     plt.yticks(fontsize=15)
-    plt.show()
+    #fig.savefig(f"{fig_path}/histgram.png") # TODO:save the figure in right path
+
+    if show:
+        plt.show()
 
 
     # 3D_Surface
@@ -63,8 +68,7 @@ def two_parameter_plot(df_data: pd.DataFrame, perf_name: str, par_name1: str, pa
         title = f"3D_Surface_{perf_name}",
         width=900, 
         height=600)
-    
-    fig.write_image(f"path/plot.png") # TODO
+    #fig.write_image(f"{fig_path}/plot.png") # TODO:save the figure in right path
     
     if show:
         fig.show()
@@ -95,7 +99,7 @@ def three_parameter_plot(df_data: pd.DataFrame, perf_name: str, par_name1: str, 
         title = f'{perf_name}',
         )
     fig.update_layout(width=1000, height=600)
-    fig.write_image(f"path/plot.png") # TODO
+    #fig.write_image(f"{fig_path}/plot.png") # TODO:save the figure in right path
 
     if show:
         fig.show()

--- a/data_handler/binance_handler.py
+++ b/data_handler/binance_handler.py
@@ -86,7 +86,7 @@ class BinanceHandler:
 
         if symbol_option not in valid_symbol_options:
             raise ValueError(f"Invalid symbol_option. Must be one of {valid_symbol_options}")
-        binance_path = f'{os.path.dirname(__file__)}/../database/BINANCE'
+        binance_path = f'{os.path.dirname(__file__)}/../data_base/BINANCE'
         os.makedirs(binance_path, exist_ok=True) #TODO need to switch to general path 
 
         if product_option == SPOT:

--- a/data_handler/yfinance_handler.py
+++ b/data_handler/yfinance_handler.py
@@ -2,10 +2,6 @@ import yfinance as yf
 import os
 from types_enums.yfinance_enum import yf_pool as pool
 
-import configparser
-import platform
-import pandas as pd
-
 class YFinanceHandler:
     """
     A class for handling Yahoo Finance daily data retrieval and processing.
@@ -26,11 +22,8 @@ class YFinanceHandler:
         print('yfinance handler init')
 
     def handler_download(self):
-        """
-        solve path problem in the func "save_ohlcv_dict_to_df()"
-        """
-        # os.makedirs(f'{os.path.dirname(__file__)}/../database/YFIN', exist_ok=True) 
-        # #TODO why in finlab, binance is /../..??, need to switch to general path 
+        os.makedirs(f'{os.path.dirname(__file__)}/../data_base/YFIN', exist_ok=True) 
+        #TODO why in finlab, binance is /../..??, need to switch to general path 
         self.save_ohlcv_dict_to_df()
 
     def get_yf_result(self):
@@ -111,24 +104,10 @@ class YFinanceHandler:
     
     def save_ohlcv_dict_to_df(self):
         ohlcv_dict = self.get_ohlcv_dict()
-
-        config_path = os.path.expanduser('~/vectorbt-research/config/config.ini')
-        download_config = configparser.ConfigParser()
-        download_config.read(config_path) # Load the config.ini file
-        if platform.system() == "Darwin": # Retrieve the value based on the platform
-            yfinance_path = download_config.get('path', 'mac_path')
-        elif platform.system() == "Windows":
-            yfinance_path = download_config.get('path', 'window_path')
-        
-        # create the database path file you designated
-        data_path = yfinance_path + f'/YFIN'
-        os.makedirs(data_path,  exist_ok=True)
-
-
         for key, df in ohlcv_dict.items():
             file_name = f'{key}.csv'  # Constructing the file name based on the key
-            file_path = os.path.join(data_path, file_name)
+            dir = f'{os.path.dirname(__file__)}/../data_base/YFIN/'
+            file_path = os.path.join(dir, file_name)
             df.to_csv(file_path)
         print('yfinance data saved')
-
 

--- a/script/init_candle_plot.py
+++ b/script/init_candle_plot.py
@@ -1,7 +1,7 @@
 import os
 import sys
 
-sys.path.insert(1, os.path.expanduser('~/Systematic-Sherpa')) # TODP path fix general way
+sys.path.insert(1, f"{os.getcwd()}/..")
 
 from backoffice.vbt_plot.candle import candle_graph
 

--- a/script/init_walkforward.py
+++ b/script/init_walkforward.py
@@ -9,7 +9,7 @@ sys.path.insert(1, f"{os.getcwd()}/..")
 
 
 import backoffice.walk_forward.walkforward_opt as opt
-#import backoffice.vbt_plot.optimize_plot as optplot
+import backoffice.vbt_plot.optimize_plot as optplot
 
 
 def main():
@@ -30,12 +30,9 @@ def main():
 
     res_df = pd.DataFrame(res).reset_index()
 
-    # for i in range(28):
-    #     optplot.two_parameter_plot(res_df[res_df['split_idx'] == i], "total_return", "fast_window", 'slow_window')
-
-
-
-
+    for i in range(28):
+        optplot.two_parameter_plot(res_df[res_df['split_idx'] == i], "total_return", "fast_window", 'slow_window')
+    
     # n = int(input('Which trunk would you like to see? '))
     # optplot.two_parameter_plot(res_df[res_df['split_idx'] == n], "total_return", "fast_window", 'slow_window')
 

--- a/script/init_walkforward.py
+++ b/script/init_walkforward.py
@@ -5,10 +5,11 @@ import pandas as pd
 import os
 import sys
 
-sys.path.insert(1, os.getcwd()) # TODP path fix general way
+sys.path.insert(1, f"{os.getcwd()}/..")
+
 
 import backoffice.walk_forward.walkforward_opt as opt
-import backoffice.vbt_plot.optimize_plot as optplot
+#import backoffice.vbt_plot.optimize_plot as optplot
 
 
 def main():
@@ -29,9 +30,12 @@ def main():
 
     res_df = pd.DataFrame(res).reset_index()
 
-    for i in range(28):
-        optplot.two_parameter_plot(res_df[res_df['split_idx'] == i], "total_return", "fast_window", 'slow_window')
-    
+    # for i in range(28):
+    #     optplot.two_parameter_plot(res_df[res_df['split_idx'] == i], "total_return", "fast_window", 'slow_window')
+
+
+
+
     # n = int(input('Which trunk would you like to see? '))
     # optplot.two_parameter_plot(res_df[res_df['split_idx'] == n], "total_return", "fast_window", 'slow_window')
 

--- a/script/load_binance.py
+++ b/script/load_binance.py
@@ -1,7 +1,7 @@
 import os
 import sys
 
-sys.path.insert(1, os.path.expanduser('/Users/chouwilliam/Lab3310Projects/Systematic-Sherpa'))
+sys.path.insert(1, f"{os.getcwd()}/..")
 
 from data_handler.binance_handler import BinanceHandler
 

--- a/tempt/yfinance_handler.py
+++ b/tempt/yfinance_handler.py
@@ -22,7 +22,7 @@ class YFinanceHandler:
         print('yfinance handler init')
 
     def handler_download(self):
-        os.makedirs(f'{os.path.dirname(__file__)}/../database/YFIN', exist_ok=True) 
+        os.makedirs(f'{os.path.dirname(__file__)}/../data_base/YFIN', exist_ok=True) 
         #TODO why in finlab, binance is /../..??, need to switch to general path 
         self.save_ohlcv_dict_to_df()
 
@@ -106,7 +106,7 @@ class YFinanceHandler:
         ohlcv_dict = self.get_ohlcv_dict()
         for key, df in ohlcv_dict.items():
             file_name = f'{key}.csv'  # Constructing the file name based on the key
-            dir = f'{os.path.dirname(__file__)}/../database/YFIN/'
+            dir = f'{os.path.dirname(__file__)}/../data_base/YFIN/'
             file_path = os.path.join(dir, file_name)
             df.to_csv(file_path)
         print('yfinance data saved')


### PR DESCRIPTION
.py 檔之 Path 解決方案:
1. 「不同」資料夾 (被執行程式與需要 import 的.py 位於「不同」位置)
-> sys.path.insert(1, path)

(1) 統一乾淨路徑
path = os.path.expanduser('~/Systematic-Sherpa')
(meaning: 將 ~ 取代為使用者系統目錄)

(此舉將導入 '系統使用者目錄/Systematic-Sherpa')
- 優點: 子目錄改變無須異動
- 缺點: 頂層目錄需固定為'系統使用者目錄/Systematic-Sherpa'(此處為 user/Systematic-Sherpa)，不可隨意移動

(2) 固定檔案目錄層數
path = f"{os.getcwd()}/.."
(meaning: 執行程式位置往上固定層數至頂層目錄)
- 優點: 頂層目錄(此處為 user/Systematic-Sherpa) 可隨意移動
- 缺點: 被執行程式與頂層目錄層數差不得改變 (不能移動至不同層數資料夾中)


2. 相同資料夾 (被執行程式與需要 import 的.py 位於「相同」資料夾)
-> 不用處理